### PR TITLE
feat: deprecate repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Plugin Infracost
 
+> **⚠️ DEPRECATED**: This repository is no longer maintained. The Infracost plugin functionality is now built directly into Spacelift's native plugins feature. Customers can install and configure the Infracost plugin through the Spacelift UI or API instead of using this Terraform module.
+>
+> For current documentation on using the Infracost plugin, please refer to the [Spacelift documentation](https://docs.spacelift.io).
+
+---
+
+## Legacy Documentation
+
 This module adds the `infracost` plugin to your Spacelift account.
 
 ## Usage


### PR DESCRIPTION
## Summary

Deprecates the `plugin-infracost` repository as the Infracost plugin is now natively supported in Spacelift's plugin system.

## Motivation

The Infracost plugin functionality has been integrated directly into Spacelift's native plugins feature, eliminating the need for this standalone Terraform module. Users can now install and configure the Infracost plugin through the Spacelift UI or API, providing a better user experience and reducing maintenance overhead for this separate repository.

## Changes

- Added deprecation notice at the top of README.md
- Preserved original documentation under "Legacy Documentation" section for reference
- Included link to official Spacelift documentation for current usage instructions

## Impact

**Existing Users**: This repository will remain available for reference, but no further updates will be published. Users should migrate to the native Spacelift Infracost plugin through the UI or API.

**New Users**: Should not use this module and instead should configure the Infracost plugin directly in Spacelift.

## Documentation

- [Spacelift Documentation](https://docs.spacelift.io)